### PR TITLE
added module_list to the table of contents

### DIFF
--- a/docs/source/software/systemwide/index.md
+++ b/docs/source/software/systemwide/index.md
@@ -5,6 +5,7 @@
 :maxdepth: 3
 
 Modules <modules>
+Module List <module_list>
 MPI <mpi>
 R <r>
 Matlab <matlab>


### PR DESCRIPTION
Addressing the warning 

```bash
checking consistency... /Users/r.behr/Desktop/tmpweb/rc-public-documentation/docs/source/software/systemwide/module_list.md: WARNING: document isn't included in any toctree
``` 

that would occur when running `make html` by including `module_list` in the table of contents for the `systemwide` section of `software`. If we decide that we don't want it listed in the future, we can remove it from the TOC and add the orphan metadata tag to it.  